### PR TITLE
Add animations, polish UI, and fix bugs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,6 @@
 /* App-specific styles */
 
-/* Smooth scroll behavior */
-html {
-  scroll-behavior: smooth;
-  overscroll-behavior-y: contain;
-}
-
-/* Custom selection color */
+/* Custom text selection color */
 ::selection {
   background: rgba(128, 211, 238, 0.3);
   color: #182651;
@@ -15,15 +9,15 @@ html {
 /* Focus visible styles */
 :focus-visible {
   outline: 2px solid #80D3EE;
-  outline-offset: 2px;
+  outline-offset: 3px;
+  border-radius: 4px;
 }
 
-/* Video background optimization */
+/* Video / image GPU hints */
 video {
   will-change: transform;
 }
 
-/* Image loading optimization */
 img {
   will-change: transform;
 }
@@ -31,65 +25,36 @@ img {
 /* Prevent text selection on interactive elements */
 button, a {
   user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
-/* Custom scrollbar for webkit browsers */
+/* ─── Custom scrollbar ───────────────────────────────────────────────── */
 ::-webkit-scrollbar {
   width: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: #f1f5f9;
 }
 
 ::-webkit-scrollbar-thumb {
   background: #182651;
   border-radius: 4px;
+  border: 2px solid #f1f5f9;
 }
 
 ::-webkit-scrollbar-thumb:hover {
   background: #80D3EE;
 }
 
-/* Animation delay utilities */
-.animation-delay-100 {
-  animation-delay: 100ms;
-}
-
-.animation-delay-200 {
-  animation-delay: 200ms;
-}
-
-.animation-delay-300 {
-  animation-delay: 300ms;
-}
-
-.animation-delay-400 {
-  animation-delay: 400ms;
-}
-
-.animation-delay-500 {
-  animation-delay: 500ms;
-}
-
-/* Responsive typography */
+/* ─── Responsive typography clamps ──────────────────────────────────── */
 @media (max-width: 640px) {
-  h1 {
-    font-size: 2rem !important;
-  }
-  
-  h2 {
-    font-size: 1.75rem !important;
-  }
+  h1 { font-size: clamp(1.75rem, 8vw, 2.5rem) !important; }
+  h2 { font-size: clamp(1.5rem,  7vw, 2rem)   !important; }
 }
 
-/* Print styles */
+/* ─── Print styles ───────────────────────────────────────────────────── */
 @media print {
-  nav, footer {
-    display: none;
-  }
-  
-  section {
-    page-break-inside: avoid;
-  }
+  nav, footer { display: none; }
+  section { page-break-inside: avoid; }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
-import { 
-  Instagram, 
-  Facebook, 
-  Youtube, 
+import {
+  Instagram,
+  Facebook,
+  Youtube,
   Github,
   Linkedin,
-  Mail, 
+  Mail,
   ChevronLeft,
   ChevronRight,
   MapPin,
   School,
   ArrowRight,
-  ExternalLink
+  ExternalLink,
+  ChevronDown,
 } from 'lucide-react';
-// import ScrollExpandMedia, { type HeroContentRenderProps } from './components/blocks/scroll-expansion-hero';
 import './App.css';
 import DesktopNav from './components/DesktopNav';
 import MobileNav from './components/MobileNav';
@@ -26,101 +26,61 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 
-// Animation constants for hero text movement
-// This multiplier ensures text moves completely off-screen during the scroll animation
-// const OFF_SCREEN_MULTIPLIER = 8;
-
-// Helper component for directional text animation (moves entire text block left or right)
-// interface DirectionalTextProps {
-//   text: string;
-//   translateX: number;
-//   direction: 'left' | 'right';
-//   className?: string;
-//   speedMultiplier?: number; // Multiplier to adjust speed for different text elements
-// }
-
-// const DirectionalText = ({ text, translateX, direction, className = '', speedMultiplier = 1 }: DirectionalTextProps) => {
-//   // Calculate the actual translation with direction and speed multiplier
-//   const actualTranslateX = translateX * speedMultiplier * OFF_SCREEN_MULTIPLIER;
-  
-//   return (
-//     <span
-//       className={className}
-//       style={{
-//         display: 'inline-block',
-//         transform: direction === 'left' 
-//           ? `translateX(-${actualTranslateX}px)` 
-//           : `translateX(${actualTranslateX}px)`,
-//         transition: 'transform 0.1s ease-out',
-//       }}
-//     >
-//       {text}
-//     </span>
-//   );
-// };
-
-// Sponsor logos with homepage links and descriptions
-// To update sponsor links: Replace the 'url' value with the sponsor's homepage URL
-// Format: { image: '/sponsor-X.png', url: 'https://example.com', name: 'Sponsor Name', description: '...' }
-// Set url to '' (empty string) if no link is available yet
+// ─── Sponsor data ────────────────────────────────────────────────────────────
+// Set url to '' (empty string) if no link is available yet.
 const sponsors = [
-  { image: '/sponsor-1.png', url: 'https://www.argosyfnd.org/', name: 'Argosy Foundation', description: 'The Argosy Foundation supports innovative organizations and programs that strengthen communities through education, the environment, and social services.' },
-  { image: '/sponsor-2.png', url: 'https://firstwa.org/', name: 'FIRST Washington', description: 'FIRST Washington is the regional affiliate for FIRST robotics programs in the state of Washington, inspiring young people to be science and technology leaders.' },
-  { image: '/sponsor-3.png', url: 'https://www.ghaasfoundation.org/', name: 'Gene Haas Foundation', description: 'The Gene Haas Foundation supports the growth of manufacturing in the United States by funding CNC machining education and scholarships.' },
-  { image: '/sponsor-4.png', url: 'https://ehsptsa.org/Home', name: 'EHS PTSA', description: 'The Eastlake High School PTSA supports students, families, and educators through community engagement, advocacy, and enrichment programs.' },
-  { image: '/sponsor-5.png', url: 'https://grizzlyjunk.com/', name: 'Grizzly Junk Removal', description: 'Grizzly Junk Removal provides fast, affordable, and eco-friendly junk removal services in the greater Seattle area.' },
-  { image: '/sponsor-6.png', url: 'https://www.ebay.com/str/happyglobalschoice', name: 'Happy Globals Choice', description: 'Happy Globals Choice offers a wide selection of quality products through their online storefront, supporting communities through commerce.' },
-  { image: '/sponsor-7.png', url: 'https://www.speea.org/', name: 'SPEEA', description: 'The Society of Professional Engineering Employees in Aerospace (SPEEA) represents engineers and technical workers, advocating for quality education and STEM initiatives.' },
-  { image: '/sponsor-8.png', url: '', name: 'Sponsor 8', description: '' },
-  { image: '/sponsor-9.png', url: '', name: 'Sponsor 9', description: '' },
-  { image: '/sponsor-10.png', url: 'https://happyglobalinc.com/', name: 'Happy Global Inc', description: 'Happy Global Inc is a company dedicated to bringing quality products and services to customers worldwide.' },
-  { image: '/sponsor-11.png', url: 'https://www.pagliacci.com/', name: 'Pagliacci', description: 'Pagliacci Pizza is a beloved Seattle-area pizza company known for its handcrafted pizzas and community involvement.' },
-  { image: '/sponsor-12.png', url: 'https://www.linxbot.com/', name: 'LINXBOT Inc.', description: 'LINXBOT Inc. specializes in robotics solutions, supporting STEM education and innovation in the community.' },
-  { image: '/sponsor-13.png', url: 'https://www.c2educate.com/', name: 'C2 Education', description: 'C2 Education provides personalized tutoring, test prep, and college counseling to help students achieve their academic goals.' },
+  { image: '/sponsor-1.png',  url: 'https://www.argosyfnd.org/',                  name: 'Argosy Foundation',    description: 'The Argosy Foundation supports innovative organizations and programs that strengthen communities through education, the environment, and social services.' },
+  { image: '/sponsor-2.png',  url: 'https://firstwa.org/',                         name: 'FIRST Washington',     description: 'FIRST Washington is the regional affiliate for FIRST robotics programs in the state of Washington, inspiring young people to be science and technology leaders.' },
+  { image: '/sponsor-3.png',  url: 'https://www.ghaasfoundation.org/',             name: 'Gene Haas Foundation', description: 'The Gene Haas Foundation supports the growth of manufacturing in the United States by funding CNC machining education and scholarships.' },
+  { image: '/sponsor-4.png',  url: 'https://ehsptsa.org/Home',                     name: 'EHS PTSA',             description: 'The Eastlake High School PTSA supports students, families, and educators through community engagement, advocacy, and enrichment programs.' },
+  { image: '/sponsor-5.png',  url: 'https://grizzlyjunk.com/',                     name: 'Grizzly Junk Removal', description: 'Grizzly Junk Removal provides fast, affordable, and eco-friendly junk removal services in the greater Seattle area.' },
+  { image: '/sponsor-6.png',  url: 'https://www.ebay.com/str/happyglobalschoice', name: 'Happy Globals Choice', description: 'Happy Globals Choice offers a wide selection of quality products through their online storefront, supporting communities through commerce.' },
+  { image: '/sponsor-7.png',  url: 'https://www.speea.org/',                       name: 'SPEEA',                description: 'The Society of Professional Engineering Employees in Aerospace (SPEEA) represents engineers and technical workers, advocating for quality education and STEM initiatives.' },
+  { image: '/sponsor-8.png',  url: '',                                             name: 'Our Sponsors',         description: 'We are grateful to all of our sponsors for their generous support. Contact us to learn about sponsorship opportunities.' },
+  { image: '/sponsor-9.png',  url: '',                                             name: 'Our Sponsors',         description: 'We are grateful to all of our sponsors for their generous support. Contact us to learn about sponsorship opportunities.' },
+  { image: '/sponsor-10.png', url: 'https://happyglobalinc.com/',                  name: 'Happy Global Inc',     description: 'Happy Global Inc is a company dedicated to bringing quality products and services to customers worldwide.' },
+  { image: '/sponsor-11.png', url: 'https://www.pagliacci.com/',                   name: 'Pagliacci',            description: 'Pagliacci Pizza is a beloved Seattle-area pizza company known for its handcrafted pizzas and community involvement.' },
+  { image: '/sponsor-12.png', url: 'https://www.linxbot.com/',                     name: 'LINXBOT Inc.',         description: 'LINXBOT Inc. specializes in robotics solutions, supporting STEM education and innovation in the community.' },
+  { image: '/sponsor-13.png', url: 'https://www.c2educate.com/',                   name: 'C2 Education',         description: 'C2 Education provides personalized tutoring, test prep, and college counseling to help students achieve their academic goals.' },
 ];
 
-// Sponsor carousel configuration
-// getSponsorItemWidth: calculates the width dynamically based on viewport
-// Mobile (<640px): 280px + 16px margins = 296px
-// Desktop (≥640px): 400px + 32px margins = 464px
-const getSponsorItemWidth = () => {
-  return window.innerWidth < 640 ? 296 : 464;
-};
-// SPONSOR_JUMP_FACTOR: number of sponsor slots to jump when an arrow button is clicked
-// Increase this value to jump further, decrease to jump less. Both arrows use the same factor.
-const SPONSOR_JUMP_FACTOR = 3;
-// SPONSOR_SCROLL_SPEED: pixels scrolled per animation frame (~60fps), controls auto-scroll speed
-const SPONSOR_SCROLL_SPEED = 1.0;
-// SPONSOR_JUMP_DURATION_MS: duration in milliseconds of the arrow-button acceleration animation
+// ─── Sponsor carousel configuration ─────────────────────────────────────────
+const getSponsorItemWidth = () => (window.innerWidth < 640 ? 296 : 464);
+const SPONSOR_JUMP_FACTOR    = 3;
+const SPONSOR_SCROLL_SPEED   = 1.0;
 const SPONSOR_JUMP_DURATION_MS = 500;
-// MAX_FRAME_DELTA_MS: caps dt so a tab-switch or long pause doesn't cause a huge position jump
-const MAX_FRAME_DELTA_MS = 100;
+const MAX_FRAME_DELTA_MS     = 100;
+
+// ─── Team stats ──────────────────────────────────────────────────────────────
+const teamStats = [
+  { value: '22+',  label: 'Years of Excellence' },
+  { value: '120',  label: 'Pound Competition Robot', unit: 'LBS' },
+  { value: '5',    label: 'Schools Represented' },
+  { value: '6',    label: 'Week Build Season',       unit: 'WK' },
+];
 
 function App() {
-  const [isNavVisible, setIsNavVisible] = useState(true);
+  const [isNavVisible, setIsNavVisible]       = useState(true);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  // const [isCommunityDropdownOpen, setIsCommunityDropdownOpen] = useState(false);
-  const [selectedSponsor, setSelectedSponsor] = useState<typeof sponsors[number] | null>(null);
+  const [selectedSponsor, setSelectedSponsor]   = useState<typeof sponsors[number] | null>(null);
+  const [statsVisible, setStatsVisible]         = useState(false);
 
   // Sponsor carousel refs
-  const sponsorStripRef = useRef<HTMLDivElement>(null);
-  const sponsorPosRef = useRef(0);
-  const sponsorAnimRef = useRef<number>(0);
-  const sponsorPausedRef = useRef(false);
-  // Track current item width (updates on resize)
+  const sponsorStripRef    = useRef<HTMLDivElement>(null);
+  const sponsorPosRef      = useRef(0);
+  const sponsorAnimRef     = useRef<number>(0);
+  const sponsorPausedRef   = useRef(false);
   const sponsorItemWidthRef = useRef(getSponsorItemWidth());
-  // Previous RAF timestamp for computing delta-time (used by the jump animation)
-  const prevTimestampRef = useRef<number | null>(null);
-  // Active jump animation state: null when no jump is running
+  const prevTimestampRef   = useRef<number | null>(null);
   const sponsorJumpRef = useRef<{
-    direction: 1 | -1;  // +1 = right (advance), -1 = left (reverse)
-    elapsed: number;    // ms elapsed (only advances while not paused)
-    coveredExtra: number; // extra pixels already applied to sponsorPosRef for this jump
+    direction: 1 | -1;
+    elapsed: number;
+    coveredExtra: number;
   } | null>(null);
 
- 
+  // Stats section ref for IntersectionObserver
+  const statsRef = useRef<HTMLDivElement>(null);
 
-  // Team photos
   const teamPhotos = [
     '/team-photo-1.jpg',
     '/team-photo-2.jpg',
@@ -135,54 +95,40 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const handleScroll = () => {
-      // setIsNavVisible(window.scrollY > 100);
-      setIsNavVisible(true);
-    };
-
+    const handleScroll = () => setIsNavVisible(true);
     window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Sponsor carousel animation (requestAnimationFrame-based for smooth infinite scroll)
+  // Sponsor carousel animation (rAF-based smooth infinite scroll)
   useEffect(() => {
     function animateSponsor(timestamp: number) {
-      const SPONSOR_ITEM_WIDTH = sponsorItemWidthRef.current;
-      const SPONSOR_SINGLE_WIDTH = sponsors.length * SPONSOR_ITEM_WIDTH;
+      const ITEM_W  = sponsorItemWidthRef.current;
+      const TOTAL_W = sponsors.length * ITEM_W;
 
-      // Compute delta-time in ms since the last frame (capped to avoid big jumps after a tab-switch)
       const dt = prevTimestampRef.current !== null
         ? Math.min(timestamp - prevTimestampRef.current, MAX_FRAME_DELTA_MS)
         : 0;
       prevTimestampRef.current = timestamp;
 
       if (!sponsorPausedRef.current) {
-        // Base auto-scroll
         sponsorPosRef.current += SPONSOR_SCROLL_SPEED;
 
-        // Jump animation (bell-curve ease: accelerate → fast → decelerate)
         const jump = sponsorJumpRef.current;
         if (jump) {
           jump.elapsed = Math.min(jump.elapsed + dt, SPONSOR_JUMP_DURATION_MS);
-          const progress = jump.elapsed / SPONSOR_JUMP_DURATION_MS;
-          // Position curve: (1 - cos(π·p)) / 2  →  moves from 0 to 1 with smooth ease-in-out
-          // Velocity curve (derivative): (π/2)·sin(π·p)  →  0 at start, peaks at mid, 0 at end
-          const positionFraction = (1 - Math.cos(Math.PI * progress)) / 2;
-          const targetCovered = positionFraction * SPONSOR_JUMP_FACTOR * SPONSOR_ITEM_WIDTH;
-          const delta = targetCovered - jump.coveredExtra;
-          jump.coveredExtra = targetCovered;
+          const progress       = jump.elapsed / SPONSOR_JUMP_DURATION_MS;
+          const posFraction    = (1 - Math.cos(Math.PI * progress)) / 2;
+          const targetCovered  = posFraction * SPONSOR_JUMP_FACTOR * ITEM_W;
+          const delta          = targetCovered - jump.coveredExtra;
+          jump.coveredExtra    = targetCovered;
           sponsorPosRef.current += delta * jump.direction;
-          if (jump.elapsed >= SPONSOR_JUMP_DURATION_MS) {
-            sponsorJumpRef.current = null;
-          }
+          if (jump.elapsed >= SPONSOR_JUMP_DURATION_MS) sponsorJumpRef.current = null;
         }
 
-        // Wrap position for seamless infinite loop
-        if (sponsorPosRef.current >= SPONSOR_SINGLE_WIDTH) {
-          sponsorPosRef.current -= SPONSOR_SINGLE_WIDTH;
-        } else if (sponsorPosRef.current < 0) {
-          sponsorPosRef.current += SPONSOR_SINGLE_WIDTH;
-        }
+        // Wrap for seamless loop
+        if (sponsorPosRef.current >= TOTAL_W)  sponsorPosRef.current -= TOTAL_W;
+        else if (sponsorPosRef.current < 0)    sponsorPosRef.current += TOTAL_W;
 
         if (sponsorStripRef.current) {
           sponsorStripRef.current.style.transform = `translateX(-${sponsorPosRef.current}px)`;
@@ -194,271 +140,255 @@ function App() {
     return () => cancelAnimationFrame(sponsorAnimRef.current);
   }, []);
 
-  // Update sponsor item width on resize
+  // Resize handler for sponsor item width
   useEffect(() => {
-    const handleResize = () => {
-      sponsorItemWidthRef.current = getSponsorItemWidth();
-    };
+    const handleResize = () => { sponsorItemWidthRef.current = getSponsorItemWidth(); };
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  function jumpSponsors(direction: 'left' | 'right') {
-    // Start (or restart) the smooth acceleration animation for the given direction
-    sponsorJumpRef.current = {
-      direction: direction === 'right' ? 1 : -1,
-      elapsed: 0,
-      coveredExtra: 0,
-    };
-  }
+  // Stats section visibility (trigger count-pop animation)
+  useEffect(() => {
+    const el = statsRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) setStatsVisible(true); },
+      { threshold: 0.3 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
-  // Intersection Observer for reveal animations
+  // Scroll-reveal IntersectionObserver (runs once after mount)
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('active');
-          }
+          if (entry.isIntersecting) entry.target.classList.add('active');
         });
       },
       { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
     );
-
-    document.querySelectorAll('.reveal, .stagger-children').forEach((el) => {
-      observer.observe(el);
-    });
-
+    document.querySelectorAll('.reveal, .reveal-left, .reveal-right, .reveal-scale, .stagger-children')
+      .forEach((el) => observer.observe(el));
     return () => observer.disconnect();
   }, []);
 
- const scrollToSection = (href: string) => {
-  if (href.startsWith('#')) {
-    const element = document.querySelector(href);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
-    }
-  } else {
-    // Navigate to route
-    window.location.href = href;
+  function jumpSponsors(direction: 'left' | 'right') {
+    sponsorJumpRef.current = { direction: direction === 'right' ? 1 : -1, elapsed: 0, coveredExtra: 0 };
   }
-  setIsMobileMenuOpen(false);
-};
+
+  const scrollToSection = (href: string) => {
+    if (href.startsWith('#')) {
+      document.querySelector(href)?.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      window.location.href = href;
+    }
+    setIsMobileMenuOpen(false);
+  };
 
   return (
     <div className="min-h-screen bg-white">
       {/* Navigation */}
       <nav className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ${isNavVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-full'}`}>
-              <DesktopNav isMobileMenuOpen={isMobileMenuOpen} setIsMobileMenuOpen={setIsMobileMenuOpen} />
-              <MobileNav isMobileMenuOpen={isMobileMenuOpen} setIsMobileMenuOpen={setIsMobileMenuOpen} />
+        <DesktopNav isMobileMenuOpen={isMobileMenuOpen} setIsMobileMenuOpen={setIsMobileMenuOpen} />
+        <MobileNav  isMobileMenuOpen={isMobileMenuOpen} setIsMobileMenuOpen={setIsMobileMenuOpen} />
       </nav>
 
-      {/* Scroll Expansion Hero Section */}
-      {/* <ScrollExpandMedia
-        mediaType="video"
-        mediaSrc="/IMG_1496.mp4"
-        posterSrc="/team-photo-2.jpg"
-        bgImageSrc="/team-photo-2.jpg"
-        heroContent={({ textTranslateX }: HeroContentRenderProps) => (
-          <div className="container-custom text-center px-4">
-            <div 
-              className="animate-fade-in-up"
-              style={{ animationDelay: '0.3s' }}
-            >
-              <DirectionalText 
-                text="#1294" 
-                translateX={textTranslateX} 
-                direction="left"
-                speedMultiplier={1.2}
-                className="inline-block text-light-blue font-orbitron text-sm md:text-base tracking-widest mb-4"
-              />
-            </div>
-            
-            <h1
-              className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-orbitron font-bold text-white mb-4 animate-fade-in-up"
-              style={{ animationDelay: '0.5s' }}
-            >
-              <DirectionalText
-                text="Eastlake Robotics Club"
-                translateX={textTranslateX}
-                direction="right"
-                speedMultiplier={1.5}
-              />
-            </h1>
-
-            <h2
-              className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-orbitron font-bold text-gradient mb-6 animate-fade-in-up animate-float"
-              style={{ animationDelay: '0.8s' }}
-            >
-              <DirectionalText 
-                text="Pack of Parts" 
-                translateX={textTranslateX} 
-                direction="left"
-                speedMultiplier={1.3}
-              />
-            </h2>
-            
-            <p 
-              className="text-white/80 text-base md:text-lg lg:text-xl max-w-2xl mx-auto mb-10 animate-fade-in-up"
-              style={{ animationDelay: '1.1s' }}
-            >
-              <DirectionalText 
-                text="FRC Team 1294 | Sammamish, Washington" 
-                translateX={textTranslateX} 
-                direction="left"
-                speedMultiplier={1.0}
-              />
-            </p>
-          </div>
-        )}
-        frozenContent={
-          <div className="container-custom text-center px-4">
-            <div className="mb-4">
-              <span className="inline-block text-light-blue font-orbitron text-sm md:text-base tracking-widest">
-                #1294
-              </span>
-            </div>
-            
-            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-bold text-white mb-4">
-              Eastlake Robotics Club
-            </h1>
-            
-            <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-orbitron font-bold text-gradient mb-6">
-              Pack of Parts
-            </h2>
-            
-            <p className="text-white/80 text-base md:text-lg lg:text-xl max-w-2xl mx-auto mb-10">
-              FRC Team 1294 | Sammamish, Washington
-            </p>
-            
-            <div>
-              <button 
-                onClick={() => window.location.href = '/join'}
-                className="btn-primary text-sm md:text-base animate-pulse-glow"
-              >
-                Join The Club
-              </button>
-            </div>
-          </div>
-        }
-      > */}
-
-      <div 
-          className="relative z-20 min-h-screen flex items-center justify-center"
-          style={{ 
-            background: 'black',
-          }}
-        >
-          {/* Video/Image Background for frozen section */}
-          <div className="absolute inset-0 z-0">
-              <video
-                src={"/IMG_1496.mp4"}
-                autoPlay
-                muted
-                loop
-                playsInline
-                poster={"/team-photo-2.jpg"}
-                className="absolute inset-0 w-full h-full object-cover"
-              />
-            <div className="absolute inset-0 bg-black/40" />
-          </div>
-          
-          {/* Frozen content - displays the static text with original formatting */}
-            <div className="relative z-10">
-              <div className="container-custom text-center px-4">
-            <div className="mb-4">
-              <span className="inline-block text-light-blue font-orbitron text-sm md:text-base tracking-widest">
-                #1294
-              </span>
-            </div>
-            
-            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-bold text-white mb-4">
-              Eastlake Robotics Club
-            </h1>
-            
-            <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-orbitron font-bold text-gradient mb-6">
-              Pack of Parts
-            </h2>
-            
-            <p className="text-white/80 text-base md:text-lg lg:text-xl max-w-2xl mx-auto mb-10">
-              FRC Team 1294 | Sammamish, Washington
-            </p>
-            
-            <div>
-              <button 
-                onClick={() => window.location.href = '/join'}
-                className="btn-primary text-sm md:text-base animate-pulse-glow"
-              >
-                Join The Club
-              </button>
-            </div>
-          </div>
-            </div>
+      {/* ── Hero Section ───────────────────────────────────────────────────── */}
+      <div
+        className="relative z-20 min-h-screen flex items-center justify-center"
+        style={{ background: 'black' }}
+      >
+        {/* Video background */}
+        <div className="absolute inset-0 z-0">
+          <video
+            src="/IMG_1496.mp4"
+            autoPlay
+            muted
+            loop
+            playsInline
+            poster="/team-photo-2.jpg"
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+          {/* Dark overlay with gradient tint */}
+          <div className="absolute inset-0 bg-gradient-to-br from-navy/80 via-black/50 to-black/60" />
         </div>
 
-        {/* Our Mission Section */}
+        {/* Animated dot-grid overlay */}
+        <div className="absolute inset-0 z-1 hero-dots opacity-40 pointer-events-none" />
+
+        {/* Ambient glow orb */}
+        <div
+          className="absolute hero-orb pointer-events-none"
+          style={{
+            width: '60vw',
+            height: '60vw',
+            maxWidth: 700,
+            maxHeight: 700,
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -55%)',
+            zIndex: 2,
+          }}
+        />
+
+        {/* Hero content */}
+        <div className="relative z-10 w-full">
+          <div className="container-custom text-center px-4">
+
+            {/* Team number badge */}
+            <div
+              className="mb-5 animate-fade-in-up"
+              style={{ animationDelay: '0.15s', animationFillMode: 'both' }}
+            >
+              <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-light-blue/15 border border-light-blue/30 text-light-blue font-orbitron text-sm tracking-widest backdrop-blur-sm">
+                FRC TEAM #1294
+              </span>
+            </div>
+
+            {/* Main title */}
+            <h1
+              className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-orbitron font-black text-white mb-3 leading-tight animate-fade-in-up"
+              style={{ animationDelay: '0.35s', animationFillMode: 'both' }}
+            >
+              Eastlake Robotics
+            </h1>
+
+            {/* Subtitle with glow */}
+            <h2
+              className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-orbitron font-bold mb-7 animate-fade-in-up"
+              style={{
+                animationDelay: '0.55s',
+                animationFillMode: 'both',
+                color: '#80D3EE',
+                textShadow: '0 0 40px rgba(128, 211, 238, 0.5)',
+              }}
+            >
+              Pack of Parts
+            </h2>
+
+            {/* Tagline */}
+            <p
+              className="text-white/75 text-base md:text-lg lg:text-xl max-w-xl mx-auto mb-10 font-open-sans animate-fade-in-up"
+              style={{ animationDelay: '0.75s', animationFillMode: 'both' }}
+            >
+              Sammamish, Washington · Competing since 2004
+            </p>
+
+            {/* CTA buttons */}
+            <div
+              className="flex flex-col sm:flex-row gap-4 justify-center items-center animate-fade-in-up"
+              style={{ animationDelay: '0.95s', animationFillMode: 'both' }}
+            >
+              <button
+                onClick={() => window.location.href = '/join'}
+                className="btn-primary text-sm md:text-base animate-pulse-glow px-10 py-4"
+              >
+                Join The Club
+              </button>
+              <button
+                onClick={() => scrollToSection('#join')}
+                className="inline-flex items-center gap-2 text-white/70 hover:text-light-blue transition-colors duration-300 font-semibold text-sm md:text-base group"
+              >
+                Learn More
+                <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Scroll-down indicator */}
+        <div className="scroll-indicator z-10">
+          <span className="font-orbitron text-[10px] tracking-[0.3em] text-white/40 uppercase">Scroll</span>
+          <ChevronDown className="w-4 h-4 text-light-blue/60" />
+        </div>
+      </div>
+
+      {/* ── Stats Bar ─────────────────────────────────────────────────────── */}
+      <section className="bg-navy border-b border-white/10">
+        <div ref={statsRef} className="container-custom py-10 md:py-14">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-0">
+            {teamStats.map((stat, i) => (
+              <div
+                key={i}
+                className="stat-item text-center py-6 px-4"
+              >
+                <div
+                  className={`text-4xl lg:text-5xl font-orbitron font-black text-light-blue mb-1 ${statsVisible ? 'animate-count-pop' : 'opacity-0'}`}
+                  style={{ animationDelay: statsVisible ? `${i * 0.12}s` : '0s', animationFillMode: 'both' }}
+                >
+                  {stat.value}
+                  {stat.unit && (
+                    <span className="text-xl lg:text-2xl font-semibold text-light-blue/60 ml-1">{stat.unit}</span>
+                  )}
+                </div>
+                <div
+                  className={`text-white/55 font-open-sans text-xs tracking-widest uppercase ${statsVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
+                  style={{ animationDelay: statsVisible ? `${i * 0.12 + 0.15}s` : '0s', animationFillMode: 'both' }}
+                >
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Our Mission Section ───────────────────────────────────────────── */}
       <section id="join" className="section-padding bg-white">
         <div className="container-custom">
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
+
             {/* Text Content */}
-            <div className="reveal">
-              <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-4 block">
+            <div className="reveal-left">
+              <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-3 block section-accent">
                 Our Mission
               </span>
-              <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6 leading-tight">
                 Inspiring the Next Generation of STEM Leaders
               </h2>
-              
+
               <div className="space-y-4 text-gray-600 leading-relaxed">
                 <p>
-                  The purpose of the Eastlake Robotics (Pack of Parts) Team 1294 shall be to promote 
-                  science and technology in Eastlake High School and the surrounding community through 
+                  The purpose of the Eastlake Robotics (Pack of Parts) Team 1294 shall be to promote
+                  science and technology in Eastlake High School and the surrounding community through
                   student and community programs involving engineering and other technical skills.
                 </p>
                 <p>
-                  Our mission is to inspire young people to be science and technology leaders, by engaging 
-                  them in exciting hands-on programs that build science, engineering, and technology skills, 
-                  and inspire innovation, to foster well-rounded life capabilities including self-confidence, 
+                  Our mission is to inspire young people to be science and technology leaders, by engaging
+                  them in exciting hands-on programs that build science, engineering, and technology skills,
+                  and inspire innovation, to foster well-rounded life capabilities including self-confidence,
                   communication, and leadership.
                 </p>
               </div>
 
-              {/* Stats - REMOVED: Cards removed, (22+ years, 5 schools, 6 weeks) add to a text? */}
+              <button
+                onClick={() => window.location.href = '/join'}
+                className="btn-primary-light mt-8 inline-flex items-center gap-2 group"
+              >
+                Join Us Today
+                <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />
+              </button>
             </div>
 
             {/* Photo Grid */}
-            <div className="reveal" style={{ transitionDelay: '0.2s' }}>
+            <div className="reveal-right" style={{ transitionDelay: '0.15s' }}>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-4">
-                  <div className="img-zoom rounded-2xl overflow-hidden shadow-lg">
-                    <img 
-                      src={teamPhotos[0]} 
-                      alt="Team working" 
-                      className="w-full h-48 object-cover"
-                    />
+                  <div className="img-zoom rounded-2xl overflow-hidden shadow-card">
+                    <img src={teamPhotos[0]} alt="Team working" className="w-full h-48 object-cover" />
                   </div>
-                  <div className="img-zoom rounded-2xl overflow-hidden shadow-lg">
-                    <img 
-                      src={teamPhotos[2]} 
-                      alt="Programming" 
-                      className="w-full h-64 object-cover"
-                    />
+                  <div className="img-zoom rounded-2xl overflow-hidden shadow-card">
+                    <img src={teamPhotos[2]} alt="Programming" className="w-full h-64 object-cover" />
                   </div>
                 </div>
                 <div className="space-y-4 pt-8">
-                  <div className="img-zoom rounded-2xl overflow-hidden shadow-lg">
-                    <img 
-                      src={teamPhotos[1]} 
-                      alt="Competition" 
-                      className="w-full h-64 object-cover"
-                    />
+                  <div className="img-zoom rounded-2xl overflow-hidden shadow-card">
+                    <img src={teamPhotos[1]} alt="Competition" className="w-full h-64 object-cover" />
                   </div>
-                  <div className="img-zoom rounded-2xl overflow-hidden shadow-lg">
-                    <img 
-                      src={teamPhotos[3]} 
-                      alt="Team photo" 
-                      className="w-full h-48 object-cover"
-                    />
+                  <div className="img-zoom rounded-2xl overflow-hidden shadow-card">
+                    <img src={teamPhotos[3]} alt="Team photo" className="w-full h-48 object-cover" />
                   </div>
                 </div>
               </div>
@@ -467,191 +397,178 @@ function App() {
         </div>
       </section>
 
-      {/* About The Team Section */}
+      {/* ── About The Team Section ────────────────────────────────────────── */}
       <section id="members" className="section-padding bg-gray-50">
         <div className="container-custom">
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
-            {/* Video */}
-            <div className="reveal order-2 lg:order-1">
-              <div className="relative rounded-2xl overflow-hidden shadow-2xl group w-full">
-                <iframe 
-                  className="w-full aspect-video" 
-                  src="https://www.youtube.com/embed/qIBiCYVLwaA" 
-                  title="Chairman's Award Video 2023" 
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+
+            {/* YouTube embed */}
+            <div className="reveal-left order-2 lg:order-1">
+              <div className="relative rounded-2xl overflow-hidden shadow-2xl">
+                <iframe
+                  className="w-full aspect-video"
+                  src="https://www.youtube.com/embed/qIBiCYVLwaA"
+                  title="Chairman's Award Video 2023"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                   referrerPolicy="strict-origin-when-cross-origin"
                   allowFullScreen
-                ></iframe>
+                />
               </div>
             </div>
 
             {/* Text Content */}
-            <div className="reveal order-1 lg:order-2" style={{ transitionDelay: '0.2s' }}>
-              <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-4 block">
+            <div className="reveal-right order-1 lg:order-2" style={{ transitionDelay: '0.15s' }}>
+              <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-3 block section-accent">
                 About The Team
               </span>
-              <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6">
+              <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6 leading-tight">
                 Who We Are
               </h2>
-              
+
               <div className="space-y-4 text-gray-600 leading-relaxed">
                 <p>
-                  FRC Team 1294 Pack of Parts, formerly known as Top Gun, began in 2004. Over the past 
-                  22 years, Pack of Parts (POP) has grown to be a consistently diverse group of dedicated 
+                  FRC Team 1294 Pack of Parts, formerly known as Top Gun, began in 2004. Over the past
+                  22 years, Pack of Parts (POP) has grown to be a consistently diverse group of dedicated
                   students from the Sammamish area.
                 </p>
                 <p>
-                  Based out of Eastlake High School, POP's members are high school (9-12) students from 
-                  Eastlake High School, Redmond High School, Tesla STEM High School, International Community 
+                  Based out of Eastlake High School, POP's members are high school (9–12) students from
+                  Eastlake High School, Redmond High School, Tesla STEM High School, International Community
                   School, and homeschool.
                 </p>
                 <p>
-                  We build a 120 lb. competition robot in just 6 weeks. Our meetings start in the fall, 
-                  with the official season for the FIRST Robotics competition starting in January and going 
+                  We build a 120 lb. competition robot in just 6 weeks. Our meetings start in the fall,
+                  with the official season for the FIRST Robotics competition starting in January and going
                   through April. No previous experience is necessary to join. We welcome new members!
                 </p>
               </div>
 
-              <button 
+              <button
                 onClick={() => window.location.href = '/join'}
-                className="btn-primary-light mt-8 inline-flex items-center gap-2"
+                className="btn-primary-light mt-8 inline-flex items-center gap-2 group"
               >
                 Learn More About Joining
-                <ArrowRight className="w-4 h-4" />
+                <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />
               </button>
             </div>
           </div>
         </div>
       </section>
 
-      {/* What is FIRST Section */}
-<section id="community" className="section-padding bg-white">
-  <div className="container-custom">
-    {/* FRC Block */}
-    <div className="reveal mb-16 lg:mb-24">
-      <div className="grid lg:grid-cols-12 gap-12 lg:gap-20 items-center">
-        
-        {/* Text Side - Wide */}
-        <div className="lg:col-span-8">
-          <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-4 block">
-            The Competition
-          </span>
-          <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6">
-            What is the FIRST Robotics Competition?
-          </h2>
-          <p className="text-gray-600 leading-relaxed text-base md:text-lg">
-            Combining the excitement of sport with the rigors of science and technology, we call the 
-            FIRST Robotics Competition the ultimate Sport for the Mind. Under strict rules, limited 
-            resources, and an intense six-week time limit, teams of students are challenged to raise 
-            funds, design a team "brand," hone teamwork skills, and build & program industrialize robots 
-            to play a difficult field game against like-minded competitors. It's as close to real-world 
-            engineering as a student can get. Volunteer professional mentors lend their time and talents 
-            to guide each team. Each season ends with an exciting FIRST Championship in Houston, TX, and Detroit, MI.
-          </p>
-        </div>
+      {/* ── What is FIRST? Section ────────────────────────────────────────── */}
+      <section id="community" className="section-padding bg-white">
+        <div className="container-custom">
 
-        {/* Image Side - Height Matched/Smaller */}
-        <div className="lg:col-span-4 flex justify-center lg:justify-end">
-          <div className="relative rounded-2xl overflow-hidden shadow-lg border border-gray-100">
-            <img 
-              src="/team-photo-8.jpg" 
-              alt="Team 1294 working on robot" 
-              className="w-full h-auto max-h-[400px] object-cover transform hover:scale-105 transition-transform duration-500"
-            />
+          {/* FRC Block */}
+          <div className="reveal mb-16 lg:mb-24">
+            <div className="grid lg:grid-cols-12 gap-12 lg:gap-20 items-center">
+
+              <div className="lg:col-span-8">
+                <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-3 block section-accent">
+                  The Competition
+                </span>
+                <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6 leading-tight">
+                  What is the FIRST Robotics Competition?
+                </h2>
+                <p className="text-gray-600 leading-relaxed text-base md:text-lg">
+                  Combining the excitement of sport with the rigors of science and technology, we call the
+                  FIRST Robotics Competition the ultimate Sport for the Mind. Under strict rules, limited
+                  resources, and an intense six-week time limit, teams of students are challenged to raise
+                  funds, design a team "brand," hone teamwork skills, and build &amp; program industrialized
+                  robots to play a difficult field game against like-minded competitors. It's as close to
+                  real-world engineering as a student can get. Volunteer professional mentors lend their
+                  time and talents to guide each team. Each season ends with an exciting FIRST Championship
+                  in Houston, TX, and Detroit, MI.
+                </p>
+              </div>
+
+              <div className="lg:col-span-4 flex justify-center lg:justify-end">
+                <div className="relative rounded-2xl overflow-hidden shadow-card border border-gray-100 reveal-scale">
+                  <img
+                    src="/team-photo-8.jpg"
+                    alt="Team 1294 working on robot"
+                    className="w-full h-auto max-h-[400px] object-cover transform hover:scale-105 transition-transform duration-500"
+                  />
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-
-      </div>
-    </div>
-    
-
 
           {/* FIRST Block */}
           <div className="reveal" style={{ transitionDelay: '0.2s' }}>
             <div className="grid lg:grid-cols-[1fr_auto] gap-8 items-center">
-              {/* FRC logo – fills all the space to the left of the text.
-                  To make it smaller/larger, add a max-w-* class, e.g. max-w-xs (smaller)
-                  or remove max-h-* to let it grow taller.
-                  On mobile the logo stacks above the text. */}
               <img
                 src="/frc-logo.avif"
                 alt="FIRST Robotics Competition logo"
                 className="w-full max-h-72 object-contain mx-auto"
               />
               <div className="lg:max-w-2xl text-right">
-              <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-4 block">
-                The Organization
-              </span>
-              <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6">
-                What is FIRST?
-              </h2>
-              <p className="text-gray-600 leading-relaxed text-base md:text-lg mb-6">
-                FIRST (For Inspiration and Recognition of Science and Technology) is an international youth 
-                organization that operates the FIRST Robotics Competition, FIRST Tech Challenge, FIRST LEGO 
-                League, FIRST Lego League Jr., and FIRST LEGO League Jr. Discovery Edition competitions. 
-                FIRST was founded by inventor Dean Kamen and former MIT professor Woodie Flowers in 1989 to 
-                inspire young people's interest and participation in science and technology.
-              </p>
-              <p className="text-gray-600 leading-relaxed text-base md:text-lg mb-8">
-                FIRST is "More Than Robots". FIRST participation is proven to encourage students to pursue 
-                education and careers in STEM-related fields, inspire them to become leaders and innovators, 
-                and enhance their work and life skills.
-              </p>
-              <a 
-                href="https://www.firstinspires.org/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn-primary-light inline-flex items-center gap-2"
-              >
-                Visit FIRST Website
-                <ChevronRight className="w-4 h-4" />
-              </a>
+                <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-3 block">
+                  The Organization
+                </span>
+                <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-navy mb-6 leading-tight">
+                  What is FIRST?
+                </h2>
+                <p className="text-gray-600 leading-relaxed text-base md:text-lg mb-4">
+                  FIRST (For Inspiration and Recognition of Science and Technology) is an international
+                  youth organization that operates the FIRST Robotics Competition, FIRST Tech Challenge,
+                  FIRST LEGO League, and more. FIRST was founded by inventor Dean Kamen and former MIT
+                  professor Woodie Flowers in 1989 to inspire young people's interest in science and
+                  technology.
+                </p>
+                <p className="text-gray-600 leading-relaxed text-base md:text-lg mb-8">
+                  FIRST is "More Than Robots." FIRST participation is proven to encourage students to
+                  pursue education and careers in STEM-related fields, inspire them to become leaders
+                  and innovators, and enhance their work and life skills.
+                </p>
+                <a
+                  href="https://www.firstinspires.org/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-primary-light inline-flex items-center gap-2 group"
+                >
+                  Visit FIRST Website
+                  <ChevronRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-200" />
+                </a>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Sponsors Section */}
+      {/* ── Sponsors Section ──────────────────────────────────────────────── */}
       <section id="donate" className="section-padding bg-navy overflow-hidden">
         <div className="container-custom mb-12">
           <div className="text-center reveal">
+            <span className="text-light-blue font-orbitron text-sm tracking-widest uppercase mb-3 block">
+              Our Supporters
+            </span>
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-orbitron font-bold text-white mb-4">
-              Our <span className="text-gradient">Sponsors</span>
+              Our Sponsors
             </h2>
-            <p className="text-white/70 max-w-2xl mx-auto">
-              We are incredibly grateful to the following organizations that keep our team running. 
+            <p className="text-white/65 max-w-2xl mx-auto mb-6">
+              We are incredibly grateful to the following organizations that keep our team running.
               If you would like to become a sponsor, please contact us.
             </p>
-            <button 
+            <button
               onClick={() => window.location.href = '/donate'}
-              className="mt-6 btn-primary"
+              className="btn-primary"
             >
               Become a Sponsor
             </button>
           </div>
         </div>
 
-        {/* Sponsor Logo Carousel
-            - SPONSOR_JUMP_FACTOR (defined near top of file) controls how many sponsor slots
-              the arrow buttons jump per click. Both arrows use the same factor.
-            - SPONSOR_SCROLL_SPEED controls the auto-scroll speed (pixels per frame at ~60fps).
-            - Responsive sponsor item widths: Mobile (w-[280px] + mx-4 = 296px), Desktop (w-[400px] + mx-8 = 464px)
-            - To update sponsor links, modify the 'sponsors' array above the App function.
-              Each sponsor has: { image: '/sponsor-X.png', url: 'https://...', name: 'Sponsor Name' }
-              Set url to '' (empty string) if no link is available yet.
-        */}
+        {/* Sponsor Carousel */}
         <div className="flex items-center gap-4 px-4">
-          {/* Left arrow — jumps backward in the rotation */}
           <button
             onClick={() => jumpSponsors('left')}
             aria-label="Scroll sponsors left"
-            className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors duration-200"
+            className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded-full bg-white/10 hover:bg-light-blue/20 border border-white/10 hover:border-light-blue/40 text-white transition-all duration-300 hover:scale-110"
           >
             <ChevronLeft size={24} />
           </button>
 
-          {/* Scrolling strip */}
           <div className="flex-1 overflow-hidden">
             <div
               ref={sponsorStripRef}
@@ -664,7 +581,7 @@ function App() {
                 <button
                   key={index}
                   onClick={() => setSelectedSponsor(sponsor)}
-                  className="flex-shrink-0 mx-4 sm:mx-8 w-[280px] sm:w-[400px] h-48 sm:h-60 flex items-center justify-center cursor-pointer hover:opacity-80 transition-opacity duration-200"
+                  className="flex-shrink-0 mx-4 sm:mx-8 w-[280px] sm:w-[400px] h-48 sm:h-60 flex items-center justify-center cursor-pointer transition-all duration-300 hover:scale-105 group"
                   title={sponsor.name}
                   aria-label={`View details for ${sponsor.name}`}
                 >
@@ -678,11 +595,10 @@ function App() {
             </div>
           </div>
 
-          {/* Right arrow — jumps forward in the rotation */}
           <button
             onClick={() => jumpSponsors('right')}
             aria-label="Scroll sponsors right"
-            className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 text-white transition-colors duration-200"
+            className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded-full bg-white/10 hover:bg-light-blue/20 border border-white/10 hover:border-light-blue/40 text-white transition-all duration-300 hover:scale-110"
           >
             <ChevronRight size={24} />
           </button>
@@ -729,43 +645,40 @@ function App() {
         </DialogContent>
       </Dialog>
 
-      {/* Footer */}
+      {/* ── Footer ────────────────────────────────────────────────────────── */}
       <footer id="contact" className="bg-navy pt-16 pb-8 border-t border-white/10">
         <div className="container-custom">
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12">
+
             {/* Logo & Tagline */}
             <div className="lg:col-span-2 reveal">
               <div className="flex items-center gap-4 mb-4">
-                <img 
-                  src="/logo.png" 
-                  alt="Pack of Parts Logo" 
-                  className="h-16 w-auto"
-                />
+                <img src="/logo.png" alt="Pack of Parts Logo" className="h-16 w-auto" />
                 <div>
-                  <h3 className="text-white font-orbitron font-bold text-xl">
-                    Pack of Parts
-                  </h3>
+                  <h3 className="text-white font-orbitron font-bold text-xl">Pack of Parts</h3>
                   <p className="text-light-blue text-sm">FRC Team 1294</p>
                 </div>
               </div>
-              <p className="text-white/70 mb-6 max-w-md">
-                Building robots. Building futures. Inspiring the next generation of STEM leaders 
+              <p className="text-white/65 mb-6 max-w-md leading-relaxed">
+                Building robots. Building futures. Inspiring the next generation of STEM leaders
                 in Sammamish, Washington.
               </p>
-              
+
               {/* Social Icons */}
-              <div className="flex gap-4">
+              <div className="flex gap-3 flex-wrap">
                 {[
-                  { icon: Instagram, href: 'https://www.instagram.com/packofparts', label: 'Instagram' },
-                  { icon: Facebook, href: 'https://www.facebook.com/packofparts', label: 'Facebook' },
-                  { icon: Youtube, href: 'https://youtube.com/@packofparts', label: 'YouTube' },
-                  { icon: Linkedin, href: 'https://linkedin.com/company/packofparts', label: 'Linkedin' },
-                  { icon: Github, href: 'https://github.com/packofparts', label: 'Github' },
+                  { icon: Instagram, href: 'https://www.instagram.com/packofparts',  label: 'Instagram' },
+                  { icon: Facebook,  href: 'https://www.facebook.com/packofparts',   label: 'Facebook'  },
+                  { icon: Youtube,   href: 'https://youtube.com/@packofparts',        label: 'YouTube'   },
+                  { icon: Linkedin,  href: 'https://linkedin.com/company/packofparts', label: 'LinkedIn' },
+                  { icon: Github,    href: 'https://github.com/packofparts',           label: 'GitHub'   },
                 ].map((social) => (
                   <a
                     key={social.label}
                     href={social.href}
-                    className="social-icon w-12 h-12 rounded-full bg-white/10 flex items-center justify-center text-white hover:text-light-blue"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="social-icon w-11 h-11 rounded-full bg-white/10 flex items-center justify-center text-white hover:text-light-blue"
                     aria-label={social.label}
                   >
                     <social.icon className="w-5 h-5" />
@@ -775,10 +688,10 @@ function App() {
                   href="https://www.chiefdelphi.com/u/1294_pack_of_parts/summary"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="social-icon w-12 h-12 rounded-full bg-white/10 flex items-center justify-center text-white hover:text-light-blue"
+                  className="social-icon w-11 h-11 rounded-full bg-white/10 flex items-center justify-center text-white hover:text-light-blue"
                   aria-label="ChiefDelphi"
                 >
-                  <img src="/chiefdelphi-logo.svg" alt="ChiefDelphi" className="w-7 h-7" />
+                  <img src="/chiefdelphi-logo.svg" alt="ChiefDelphi" className="w-6 h-6" />
                 </a>
               </div>
             </div>
@@ -791,22 +704,16 @@ function App() {
               <h4 className="text-white font-orbitron font-semibold mb-4">Contact Us</h4>
               <ul className="space-y-4">
                 <li className="flex items-start gap-3">
-                  <Mail className="w-5 h-5 text-light-blue mt-0.5" />
-                  <div>
-                    <p className="text-white/70">info@packofparts.org</p>
-                  </div>
+                  <Mail className="w-5 h-5 text-light-blue mt-0.5 flex-shrink-0" />
+                  <p className="text-white/65">info@packofparts.org</p>
                 </li>
                 <li className="flex items-start gap-3">
-                  <MapPin className="w-5 h-5 text-light-blue mt-0.5" />
-                  <div>
-                    <p className="text-white/70">Sammamish, Washington</p>
-                  </div>
+                  <MapPin className="w-5 h-5 text-light-blue mt-0.5 flex-shrink-0" />
+                  <p className="text-white/65">Sammamish, Washington</p>
                 </li>
                 <li className="flex items-start gap-3">
-                  <School className="w-5 h-5 text-light-blue mt-0.5" />
-                  <div>
-                    <p className="text-white/70">Eastlake High School</p>
-                  </div>
+                  <School className="w-5 h-5 text-light-blue mt-0.5 flex-shrink-0" />
+                  <p className="text-white/65">Eastlake High School</p>
                 </li>
               </ul>
             </div>
@@ -814,16 +721,12 @@ function App() {
 
           {/* Bottom Bar */}
           <div className="border-t border-white/10 pt-8 text-center">
-            <p className="text-white/50 text-sm">
+            <p className="text-white/40 text-sm">
               &copy; {new Date().getFullYear()} Pack of Parts (FRC 1294). All rights reserved.
             </p>
           </div>
         </div>
       </footer>
-
-      {/* Summer Camps Section - Anchor target */}
-      <div id="camps" className="hidden" />
-      {/* </ScrollExpandMedia> */}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,9 @@ const sponsors = [
 ];
 
 // ─── Sponsor carousel configuration ─────────────────────────────────────────
-const getSponsorItemWidth = () => (window.innerWidth < 640 ? 296 : 464);
+// Mobile  (<640px): w-[280px] + mx-4 (16px × 2 sides) = 312px
+// Desktop (≥640px): w-[400px] + mx-8 (32px × 2 sides) = 464px
+const getSponsorItemWidth = () => (window.innerWidth < 640 ? 312 : 464);
 const SPONSOR_JUMP_FACTOR    = 3;
 const SPONSOR_SCROLL_SPEED   = 1.0;
 const SPONSOR_JUMP_DURATION_MS = 500;
@@ -216,7 +218,7 @@ function App() {
         </div>
 
         {/* Animated dot-grid overlay */}
-        <div className="absolute inset-0 z-1 hero-dots opacity-40 pointer-events-none" />
+        <div className="absolute inset-0 z-[1] hero-dots opacity-40 pointer-events-none" />
 
         {/* Ambient glow orb */}
         <div

--- a/src/Donate.css
+++ b/src/Donate.css
@@ -2,45 +2,69 @@
 html, body {
   overscroll-behavior-y: contain;
 }
-/* Impact Cards */
+
+/* ─── Impact Cards ──────────────────────────────────────────────────── */
 .impact-card {
   background: white;
   padding: 2rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(128, 211, 238, 0.2);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
+  border: 1px solid rgba(128, 211, 238, 0.15);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.05);
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.35s ease,
+              border-color 0.35s ease;
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+}
+
+.impact-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, #80D3EE, transparent);
+  transform: scaleX(0);
+  transition: transform 0.4s ease;
 }
 
 .impact-card:hover {
-  transform: translateY(-8px);
-  box-shadow: 0 12px 32px rgba(24, 38, 81, 0.15);
-  border-color: rgba(128, 211, 238, 0.5);
+  transform: translateY(-10px);
+  box-shadow: 0 24px 48px rgba(24, 38, 81, 0.14);
+  border-color: rgba(128, 211, 238, 0.4);
 }
 
-/* Donation Method Cards */
+.impact-card:hover::before {
+  transform: scaleX(1);
+}
+
+/* ─── Donation Method Cards ─────────────────────────────────────────── */
 .donation-method-card {
   background: white;
   padding: 2.5rem;
   border-radius: 1.5rem;
-  border: 2px solid rgba(128, 211, 238, 0.2);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
-  transition: all 0.3s ease;
+  border: 1px solid rgba(128, 211, 238, 0.2);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.35s ease,
+              border-color 0.35s ease;
 }
 
 .donation-method-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 12px 32px rgba(24, 38, 81, 0.2);
+  box-shadow: 0 20px 48px rgba(24, 38, 81, 0.15);
   border-color: rgba(128, 211, 238, 0.5);
 }
 
-/* Tax Info Card */
+/* ─── Tax Info Card ─────────────────────────────────────────────────── */
 .tax-info-card {
   background: white;
   padding: 3rem;
   border-radius: 2rem;
-  border: 2px solid rgba(128, 211, 238, 0.3);
-  box-shadow: 0 8px 32px rgba(24, 38, 81, 0.1);
+  border: 1px solid rgba(128, 211, 238, 0.25);
+  box-shadow: 0 8px 40px rgba(24, 38, 81, 0.08);
 }
 
 @media (max-width: 768px) {
@@ -49,26 +73,31 @@ html, body {
   }
 }
 
-/* FAQ Items */
+/* ─── FAQ Items ─────────────────────────────────────────────────────── */
 .faq-item {
   background: white;
-  padding: 1.5rem;
+  padding: 1.5rem 1.75rem;
   border-radius: 1rem;
   border-left: 4px solid #80D3EE;
-  box-shadow: 0 2px 8px rgba(24, 38, 81, 0.06);
-  transition: all 0.3s ease;
+  border-top: 1px solid rgba(128, 211, 238, 0.1);
+  border-right: 1px solid rgba(128, 211, 238, 0.1);
+  border-bottom: 1px solid rgba(128, 211, 238, 0.1);
+  box-shadow: 0 2px 12px rgba(24, 38, 81, 0.06);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.3s ease;
 }
 
 .faq-item:hover {
-  box-shadow: 0 8px 24px rgba(24, 38, 81, 0.12);
-  transform: translateX(8px);
+  box-shadow: 0 10px 32px rgba(24, 38, 81, 0.12);
+  transform: translateX(6px);
 }
 
-/* Social Icons */
+/* ─── Social Icons ──────────────────────────────────────────────────── */
 .social-icon {
-  transition: all 0.3s ease;
+  transition: transform 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
 }
 
 .social-icon:hover {
-  transform: scale(1.1);
+  transform: translateY(-4px) scale(1.1);
+  box-shadow: 0 6px 20px rgba(128, 211, 238, 0.25);
 }

--- a/src/Donate.tsx
+++ b/src/Donate.tsx
@@ -74,7 +74,7 @@ function Donate() {
       { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
     );
 
-    document.querySelectorAll('.reveal').forEach((el) => {
+    document.querySelectorAll('.reveal, .reveal-left, .reveal-right, .reveal-scale').forEach((el) => {
       observer.observe(el);
     });
 
@@ -104,33 +104,47 @@ function Donate() {
 
       {/* Hero Section */}
       <section className="relative min-h-[60vh] flex items-center justify-center overflow-hidden bg-navy pt-20">
-        {/* Animated Background Pattern */}
-        <div className="absolute inset-0 opacity-10">
-          <div className="absolute inset-0 hero-gradient" />
-        </div>
+        {/* Dot-grid background */}
+        <div className="absolute inset-0 hero-dots opacity-30 pointer-events-none" />
+
+        {/* Ambient glow */}
+        <div
+          className="absolute hero-orb pointer-events-none opacity-50"
+          style={{
+            width: '50vw',
+            height: '50vw',
+            maxWidth: 600,
+            maxHeight: 600,
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
 
         {/* Hero Content */}
-        <div className="relative z-10 container-custom text-center px-4 py-20">
-          <div 
+        <div className="relative z-10 container-custom text-center px-4 py-24">
+          <div
             className="animate-fade-in-up"
-            style={{ animationDelay: '0.1s' }}
+            style={{ animationDelay: '0.1s', animationFillMode: 'both' }}
           >
-            <Heart className="w-16 h-16 text-light-blue mx-auto mb-6" />
+            <div className="w-20 h-20 rounded-full bg-light-blue/15 border border-light-blue/30 flex items-center justify-center mx-auto mb-6 backdrop-blur-sm animate-glow-breathe">
+              <Heart className="w-10 h-10 text-light-blue" />
+            </div>
           </div>
-          
-          <h1 
-            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-bold text-white mb-4 animate-fade-in-up"
-            style={{ animationDelay: '0.25s' }}
+
+          <h1
+            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-black text-white mb-5 leading-tight animate-fade-in-up"
+            style={{ animationDelay: '0.25s', animationFillMode: 'both' }}
           >
-            Support Our <span className="text-gradient">Mission</span>
+            Support Our Mission
           </h1>
-          
-          <p 
-            className="text-white/80 text-base md:text-lg lg:text-xl max-w-3xl mx-auto animate-fade-in-up"
-            style={{ animationDelay: '0.4s' }}
+
+          <p
+            className="text-white/75 text-base md:text-lg lg:text-xl max-w-3xl mx-auto animate-fade-in-up"
+            style={{ animationDelay: '0.45s', animationFillMode: 'both' }}
           >
-            Pack of Parts is a non-profit organization. We fund our activities from club participation fees, 
-            corporate sponsors, and generous supporters like you. Your donation helps inspire the next generation 
+            Pack of Parts is a non-profit organization. We fund our activities from club participation fees,
+            corporate sponsors, and generous supporters like you. Your donation helps inspire the next generation
             of STEM leaders.
           </p>
         </div>

--- a/src/Join.css
+++ b/src/Join.css
@@ -2,68 +2,128 @@
 html, body {
   overscroll-behavior-y: contain;
 }
-/* Benefit Cards */
+
+/* ─── Benefit Cards ─────────────────────────────────────────────────── */
 .benefit-card {
   background: white;
   padding: 2rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(128, 211, 238, 0.2);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
+  border: 1px solid rgba(128, 211, 238, 0.15);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.05);
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.35s ease,
+              border-color 0.35s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.benefit-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(128, 211, 238, 0.06) 0%, transparent 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .benefit-card:hover {
   transform: translateY(-8px);
-  box-shadow: 0 12px 32px rgba(24, 38, 81, 0.15);
-  border-color: rgba(128, 211, 238, 0.4);
+  box-shadow: 0 20px 48px rgba(24, 38, 81, 0.14);
+  border-color: rgba(128, 211, 238, 0.45);
 }
 
-/* Info Card */
+.benefit-card:hover::before {
+  opacity: 1;
+}
+
+/* ─── Info Card ─────────────────────────────────────────────────────── */
 .info-card-join {
   background: linear-gradient(135deg, #182651 0%, rgba(24, 38, 81, 0.95) 100%);
   padding: 2.5rem;
   border-radius: 1.5rem;
   border: 1px solid rgba(128, 211, 238, 0.2);
-  box-shadow: 0 8px 32px rgba(24, 38, 81, 0.2);
+  box-shadow: 0 8px 40px rgba(24, 38, 81, 0.25);
+  position: relative;
+  overflow: hidden;
 }
 
-/* Role Cards */
+.info-card-join::after {
+  content: '';
+  position: absolute;
+  top: -50%;
+  right: -30%;
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(128, 211, 238, 0.08) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+/* ─── Role Cards ────────────────────────────────────────────────────── */
 .role-card {
   background: white;
   padding: 2rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(128, 211, 238, 0.2);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  transition: all 0.3s ease;
+  border: 1px solid rgba(128, 211, 238, 0.15);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.05);
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.35s ease,
+              border-color 0.35s ease;
   height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.role-card::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #80D3EE, #7FC3F2);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .role-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 24px rgba(24, 38, 81, 0.1);
+  transform: translateY(-6px);
+  box-shadow: 0 16px 40px rgba(24, 38, 81, 0.12);
   border-color: rgba(128, 211, 238, 0.5);
 }
 
-/* FAQ Items (reusing from Contact but with slight adjustments) */
+.role-card:hover::before {
+  transform: scaleX(1);
+}
+
+/* ─── FAQ Items ─────────────────────────────────────────────────────── */
 .faq-item {
   background: white;
-  padding: 1.5rem;
+  padding: 1.5rem 1.75rem;
   border-radius: 1rem;
   border-left: 4px solid #80D3EE;
-  box-shadow: 0 2px 8px rgba(24, 38, 81, 0.06);
-  transition: all 0.3s ease;
+  border-top: 1px solid rgba(128, 211, 238, 0.1);
+  border-right: 1px solid rgba(128, 211, 238, 0.1);
+  border-bottom: 1px solid rgba(128, 211, 238, 0.1);
+  box-shadow: 0 2px 12px rgba(24, 38, 81, 0.06);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.3s ease,
+              border-left-color 0.3s ease;
 }
 
 .faq-item:hover {
-  box-shadow: 0 8px 24px rgba(24, 38, 81, 0.12);
-  transform: translateX(8px);
+  box-shadow: 0 10px 32px rgba(24, 38, 81, 0.12);
+  transform: translateX(6px);
+  border-left-color: #7FC3F2;
 }
 
-/* Social Icons */
+/* ─── Social Icons ──────────────────────────────────────────────────── */
 .social-icon {
-  transition: all 0.3s ease;
+  transition: transform 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
 }
 
 .social-icon:hover {
-  transform: scale(1.1);
+  transform: translateY(-4px) scale(1.1);
+  box-shadow: 0 6px 20px rgba(128, 211, 238, 0.25);
 }

--- a/src/Join.tsx
+++ b/src/Join.tsx
@@ -196,7 +196,7 @@ function Join() {
       { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
     );
 
-    document.querySelectorAll('.reveal').forEach((el) => {
+    document.querySelectorAll('.reveal, .reveal-left, .reveal-right, .reveal-scale').forEach((el) => {
       observer.observe(el);
     });
 
@@ -225,35 +225,47 @@ function Join() {
       </nav>
 
       {/* Hero Section */}
-      <section className="relative min-h-[50vh] flex items-center justify-center overflow-hidden bg-navy pt-20">
-        {/* Animated Background Pattern */}
-        <div className="absolute inset-0 opacity-10">
-          <div className="absolute inset-0 hero-gradient" />
-        </div>
+      <section className="relative min-h-[55vh] flex items-center justify-center overflow-hidden bg-navy pt-20">
+        {/* Dot-grid background */}
+        <div className="absolute inset-0 hero-dots opacity-30 pointer-events-none" />
+
+        {/* Ambient glow */}
+        <div
+          className="absolute hero-orb pointer-events-none opacity-60"
+          style={{
+            width: '50vw',
+            height: '50vw',
+            maxWidth: 600,
+            maxHeight: 600,
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
 
         {/* Hero Content */}
-        <div className="relative z-10 container-custom text-center px-4 py-20">
-          <div 
+        <div className="relative z-10 container-custom text-center px-4 py-24">
+          <div
             className="animate-fade-in-up"
-            style={{ animationDelay: '0.1s' }}
+            style={{ animationDelay: '0.1s', animationFillMode: 'both' }}
           >
-            <span className="inline-block text-light-blue font-orbitron text-sm md:text-base tracking-widest mb-4">
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-light-blue/15 border border-light-blue/30 text-light-blue font-orbitron text-sm tracking-widest mb-6 backdrop-blur-sm">
               JOIN THE TEAM
             </span>
           </div>
-          
-          <h1 
-            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-bold text-white mb-4 animate-fade-in-up"
-            style={{ animationDelay: '0.25s' }}
+
+          <h1
+            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-black text-white mb-5 leading-tight animate-fade-in-up"
+            style={{ animationDelay: '0.25s', animationFillMode: 'both' }}
           >
-            Become a Member of Pack of Parts
+            Become a Member of<br className="hidden sm:block" /> Pack of Parts
           </h1>
-          
-          <p 
-            className="text-white/80 text-base md:text-lg lg:text-xl max-w-2xl mx-auto animate-fade-in-up"
-            style={{ animationDelay: '0.4s' }}
+
+          <p
+            className="text-white/75 text-base md:text-lg lg:text-xl max-w-2xl mx-auto animate-fade-in-up"
+            style={{ animationDelay: '0.45s', animationFillMode: 'both' }}
           >
-            Join FRC Team 1294 and become part of a community that builds robots, 
+            Join FRC Team 1294 and become part of a community that builds robots,
             develops skills, and creates lifelong memories.
           </p>
         </div>
@@ -317,7 +329,7 @@ function Join() {
       <section className="section-padding bg-gray-50">
         <div className="container-custom">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div className="reveal">
+            <div className="reveal-left">
               <h2 className="text-3xl md:text-4xl font-orbitron font-bold text-navy mb-6">
                 Who Can Join?
               </h2>
@@ -353,8 +365,8 @@ function Join() {
                     <div>
                       <h4 className="text-white font-semibold mb-1">Season Schedule</h4>
                       <p className="text-white/70 text-sm">
-                        Pre-Season: September - December (Mon, Wen)<br />
-                        Competition Season: January - April (Mon, Wen, Fri, Sat)<br />
+                        Pre-Season: September – December (Mon, Wed)<br />
+                        Competition Season: January – April (Mon, Wed, Fri, Sat)<br />
                       </p>
                     </div>
                   </div>
@@ -364,7 +376,7 @@ function Join() {
                     <div>
                       <h4 className="text-white font-semibold mb-1">Time Commitment</h4>
                       <p className="text-white/70 text-sm">
-                        Attend atleast 65% of meetings a month 
+                        Attend at least 65% of meetings a month
                       </p>
                     </div>
                   </div>
@@ -497,7 +509,7 @@ function Join() {
               },
               {
                 question: "How much does it cost to join?",
-                answer: "There is a 250 dollar club fee when joining. Transportation to events is not provivded and food is also not provided sometimes."
+                answer: "There is a $250 club fee when joining. Transportation to events is not provided and food may not always be provided."
               },
               {
                 question: "Will this help with college applications?",

--- a/src/components/DesktopNav.tsx
+++ b/src/components/DesktopNav.tsx
@@ -10,41 +10,65 @@ export default function DesktopNav({
 }) {
   const { pathname } = useLocation();
   const navLinks = [
-    { name: 'Join The Club', href: '/join' },
-    { name: 'For Members', href: '/members' },
-    { name: 'Donate', href: '/donate' },
-    { name: 'Contact Us', href: '/contact' },
-    { name: 'Summer Camps', href: '/summer-camps' },
+    { name: 'Join The Club',  href: '/join' },
+    { name: 'For Members',    href: '/members' },
+    { name: 'Donate',         href: '/donate' },
+    { name: 'Contact Us',     href: '/contact' },
+    { name: 'Summer Camps',   href: '/summer-camps' },
   ];
+
   return (
     <div className="container-custom pt-4 pb-0">
-      <div className="nav-glass rounded-pill px-4 md:px-8 py-3 flex items-center justify-between">
+      <div
+        className="nav-glass rounded-pill px-4 md:px-8 py-3 flex items-center justify-between"
+        style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.08)' }}
+      >
         {/* Logo */}
-        <a href="/" className="flex items-center gap-3">
-          <img src="/logo.png" alt="Pack of Parts Logo" className="h-10 w-auto" />
-          <span className="hidden sm:block text-white font-orbitron font-bold text-sm md:text-base">Pack of Parts</span>
+        <a href="/" className="flex items-center gap-3 group">
+          <img
+            src="/logo.png"
+            alt="Pack of Parts Logo"
+            className="h-10 w-auto transition-transform duration-300 group-hover:scale-105"
+          />
+          <span className="hidden sm:block text-white font-orbitron font-bold text-sm md:text-base tracking-wide transition-colors duration-200 group-hover:text-light-blue">
+            Pack of Parts
+          </span>
         </a>
 
         {/* Desktop Navigation */}
-        <div className="hidden lg:flex items-center gap-6 xl:gap-8">
+        <div className="hidden lg:flex items-center gap-1 xl:gap-2">
           {navLinks.map((link) => {
             const isActive = pathname === link.href;
             return (
               <a
                 key={link.name}
                 href={link.href}
-                className={`text-xs xl:text-sm font-semibold uppercase tracking-wide link-underline transition-colors duration-200 ${
-                  isActive ? 'text-light-blue' : 'text-white/90 hover:text-light-blue'
-                }`}
+                className={`
+                  relative px-3 xl:px-4 py-2 rounded-full
+                  text-xs xl:text-sm font-semibold uppercase tracking-wide
+                  transition-all duration-200
+                  ${isActive
+                    ? 'text-light-blue bg-light-blue/10'
+                    : 'text-white/85 hover:text-light-blue hover:bg-white/5'
+                  }
+                `}
               >
                 {link.name}
+                {/* Active indicator dot */}
+                {isActive && (
+                  <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-light-blue" />
+                )}
               </a>
             );
           })}
         </div>
 
         {/* Mobile Menu Button */}
-        <button onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)} className="lg:hidden text-white p-3 min-w-[48px] min-h-[48px] flex items-center justify-center">
+        <button
+          onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+          className="lg:hidden text-white p-3 min-w-[48px] min-h-[48px] flex items-center justify-center rounded-full hover:bg-white/10 transition-colors duration-200"
+          aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
+        >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
       </div>

--- a/src/contact.tsx
+++ b/src/contact.tsx
@@ -58,7 +58,7 @@ function Contact() {
       { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
     );
 
-    document.querySelectorAll('.reveal').forEach((el) => observer.observe(el));
+    document.querySelectorAll('.reveal, .reveal-left, .reveal-right, .reveal-scale').forEach((el) => observer.observe(el));
     return () => observer.disconnect();
   }, []);
 
@@ -144,17 +144,36 @@ markerEl.innerHTML = `
 
       {/* Hero */}
       <section className="relative min-h-[50vh] flex items-center justify-center overflow-hidden bg-navy pt-20">
-        <div className="absolute inset-0 opacity-10">
-          <div className="absolute inset-0 hero-gradient" />
-        </div>
-        <div className="relative z-10 container-custom text-center px-4 py-20">
-          <div className="animate-fade-in-up" style={{ animationDelay: '0.1s' }}>
-            <span className="inline-block text-light-blue font-orbitron text-sm md:text-base tracking-widest mb-4">GET IN TOUCH</span>
+        {/* Dot-grid background */}
+        <div className="absolute inset-0 hero-dots opacity-30 pointer-events-none" />
+
+        {/* Ambient glow */}
+        <div
+          className="absolute hero-orb pointer-events-none opacity-50"
+          style={{
+            width: '50vw', height: '50vw',
+            maxWidth: 600, maxHeight: 600,
+            top: '50%', left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }}
+        />
+
+        <div className="relative z-10 container-custom text-center px-4 py-24">
+          <div className="animate-fade-in-up" style={{ animationDelay: '0.1s', animationFillMode: 'both' }}>
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-light-blue/15 border border-light-blue/30 text-light-blue font-orbitron text-sm tracking-widest mb-6 backdrop-blur-sm">
+              GET IN TOUCH
+            </span>
           </div>
-          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-bold text-white mb-4 animate-fade-in-up" style={{ animationDelay: '0.25s' }}>
-            Contact <span className="text-gradient">Us</span>
+          <h1
+            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-orbitron font-black text-white mb-5 leading-tight animate-fade-in-up"
+            style={{ animationDelay: '0.25s', animationFillMode: 'both' }}
+          >
+            Contact Us
           </h1>
-          <p className="text-white/80 text-base md:text-lg lg:text-xl max-w-2xl mx-auto animate-fade-in-up" style={{ animationDelay: '0.4s' }}>
+          <p
+            className="text-white/75 text-base md:text-lg lg:text-xl max-w-2xl mx-auto animate-fade-in-up"
+            style={{ animationDelay: '0.45s', animationFillMode: 'both' }}
+          >
             Have questions about joining, sponsorships, or camps? We'd love to hear from you.
           </p>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -255,10 +255,9 @@
   }
 
   .sponsor-logo:hover {
-    filter: grayscale(0%);
+    filter: grayscale(0%) drop-shadow(0 0 12px rgba(128, 211, 238, 0.4));
     opacity: 1;
     transform: scale(1.08);
-    filter: drop-shadow(0 0 12px rgba(128, 211, 238, 0.4));
   }
 
   /* Social icon hover */

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,7 @@
     --input: 240 5.9% 90%;
     --ring: 195 75% 72%;
     --radius: 0.625rem;
-    
+
     /* Custom easing functions */
     --ease-robotic: cubic-bezier(0.16, 1, 0.3, 1);
     --ease-hydraulic: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -40,17 +40,17 @@
   * {
     @apply border-border;
   }
-  
+
   html {
     scroll-behavior: smooth;
     overscroll-behavior-y: contain;
   }
-  
+
   body {
     @apply bg-background text-foreground font-open-sans antialiased;
     overflow-x: hidden;
   }
-  
+
   h1, h2, h3, h4, h5, h6 {
     @apply font-orbitron;
   }
@@ -63,59 +63,137 @@
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
   }
-  
+
   /* Gradient overlay for hero */
   .hero-gradient {
     background: linear-gradient(135deg, rgba(24, 38, 81, 0.9) 0%, rgba(24, 38, 81, 0.7) 50%, rgba(128, 211, 238, 0.4) 100%);
   }
-  
+
+  /* Animated dot-grid background for hero */
+  .hero-dots {
+    background-image: radial-gradient(
+      circle at 1px 1px,
+      rgba(128, 211, 238, 0.22) 1px,
+      transparent 0
+    );
+    background-size: 48px 48px;
+    animation: dots-drift 25s linear infinite;
+  }
+
+  @keyframes dots-drift {
+    0%   { background-position: 0 0; }
+    100% { background-position: 48px 48px; }
+  }
+
+  /* Glowing orb / ambient light */
+  .hero-orb {
+    background: radial-gradient(circle, rgba(128, 211, 238, 0.25) 0%, transparent 70%);
+    filter: blur(60px);
+    border-radius: 50%;
+  }
+
   /* Button styles */
   .btn-primary {
     @apply px-8 py-3 border-2 border-light-blue text-white font-semibold rounded-pill transition-all duration-300;
     background: transparent;
+    position: relative;
+    overflow: hidden;
   }
-  
+
+  .btn-primary::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(128, 211, 238, 0.15);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s var(--ease-precision);
+    border-radius: inherit;
+  }
+
+  .btn-primary:hover::before {
+    transform: scaleX(1);
+  }
+
   .btn-primary:hover {
-    @apply bg-light-blue/20;
-    box-shadow: 0 0 20px rgba(128, 211, 238, 0.4);
+    box-shadow: 0 0 24px rgba(128, 211, 238, 0.5), 0 0 48px rgba(128, 211, 238, 0.15);
     transform: translateY(-2px) scale(1.02);
   }
-  
+
+  .btn-primary:active {
+    transform: translateY(0) scale(0.99);
+  }
+
   /* Button variant for light backgrounds */
   .btn-primary-light {
     @apply px-8 py-3 border-2 border-light-blue text-navy font-semibold rounded-pill transition-all duration-300;
     background: transparent;
+    position: relative;
+    overflow: hidden;
   }
-  
+
+  .btn-primary-light::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(128, 211, 238, 0.12);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s var(--ease-precision);
+    border-radius: inherit;
+  }
+
+  .btn-primary-light:hover::before {
+    transform: scaleX(1);
+  }
+
   .btn-primary-light:hover {
-    @apply bg-light-blue/20;
     box-shadow: 0 0 20px rgba(128, 211, 238, 0.4);
     transform: translateY(-2px) scale(1.02);
   }
-  
+
+  .btn-primary-light:active {
+    transform: translateY(0) scale(0.99);
+  }
+
   /* Section padding */
   .section-padding {
     @apply py-20 md:py-28 lg:py-32;
   }
-  
+
   /* Container */
   .container-custom {
     @apply w-full px-4 sm:px-6 lg:px-8 xl:px-12 mx-auto;
     max-width: 1400px;
   }
-  
+
   /* Text gradient */
   .text-gradient {
     color: #FFFFFF;
     -webkit-text-fill-color: #FFFFFF;
   }
-  
+
+  /* Animated gradient text for light backgrounds */
+  .text-gradient-animated {
+    background: linear-gradient(90deg, #80D3EE, #7FC3F2, #182651, #80D3EE);
+    background-size: 300% auto;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    animation: gradient-shift 5s linear infinite;
+  }
+
+  @keyframes gradient-shift {
+    0%   { background-position: 0% center; }
+    100% { background-position: 300% center; }
+  }
+
   /* Link underline animation */
   .link-underline {
     position: relative;
     display: inline-block;
   }
-  
+
   .link-underline::after {
     content: '';
     position: absolute;
@@ -127,82 +205,278 @@
     transition: all 0.3s var(--ease-precision);
     transform: translateX(-50%);
   }
-  
+
   .link-underline:hover::after {
     width: 100%;
   }
-  
+
   /* Card hover effect */
   .card-hover {
     @apply transition-all duration-300;
+    box-shadow: 0 4px 24px rgba(24, 38, 81, 0.08);
   }
-  
+
   .card-hover:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 20px 40px rgba(24, 38, 81, 0.15);
+    transform: translateY(-6px);
+    box-shadow: 0 20px 48px rgba(24, 38, 81, 0.18);
   }
-  
+
+  /* Card with glow border on hover */
+  .card-glow-hover {
+    @apply transition-all duration-300;
+    border: 1px solid rgba(128, 211, 238, 0.15);
+    box-shadow: 0 4px 24px rgba(24, 38, 81, 0.06);
+  }
+
+  .card-glow-hover:hover {
+    border-color: rgba(128, 211, 238, 0.5);
+    box-shadow: 0 0 0 1px rgba(128, 211, 238, 0.2), 0 16px 48px rgba(24, 38, 81, 0.15);
+    transform: translateY(-5px);
+  }
+
   /* Image hover zoom */
   .img-zoom {
     @apply overflow-hidden;
   }
-  
+
   .img-zoom img {
     @apply transition-transform duration-500;
   }
-  
+
   .img-zoom:hover img {
     transform: scale(1.05);
   }
-  
+
   /* Sponsor logo grayscale */
   .sponsor-logo {
     @apply transition-all duration-300;
     filter: grayscale(100%);
-    opacity: 0.7;
+    opacity: 0.65;
   }
-  
+
   .sponsor-logo:hover {
     filter: grayscale(0%);
     opacity: 1;
-    transform: scale(1.1);
+    transform: scale(1.08);
+    filter: drop-shadow(0 0 12px rgba(128, 211, 238, 0.4));
   }
-  
+
   /* Social icon hover */
   .social-icon {
     @apply transition-all duration-300;
   }
-  
+
   .social-icon:hover {
     transform: translateY(-5px) scale(1.1);
     background: rgba(128, 211, 238, 0.2);
     box-shadow: 0 5px 20px rgba(128, 211, 238, 0.3);
   }
-  
-  /* Scroll reveal animation classes */
+
+  /* ─── Scroll-reveal base classes ─────────────────────────────── */
+
+  /* Standard fade-up reveal */
   .reveal {
     opacity: 0;
     transform: translateY(30px);
-    transition: all 0.7s var(--ease-robotic);
+    transition: opacity 0.7s var(--ease-robotic),
+                transform 0.7s var(--ease-robotic);
   }
-  
+
   .reveal.active {
     opacity: 1;
     transform: translateY(0);
   }
-  
+
+  /* Slide from left */
+  .reveal-left {
+    opacity: 0;
+    transform: translateX(-40px);
+    transition: opacity 0.7s var(--ease-robotic),
+                transform 0.7s var(--ease-robotic);
+  }
+
+  .reveal-left.active {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  /* Slide from right */
+  .reveal-right {
+    opacity: 0;
+    transform: translateX(40px);
+    transition: opacity 0.7s var(--ease-robotic),
+                transform 0.7s var(--ease-robotic);
+  }
+
+  .reveal-right.active {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  /* Scale in */
+  .reveal-scale {
+    opacity: 0;
+    transform: scale(0.88);
+    transition: opacity 0.6s var(--ease-hydraulic),
+                transform 0.6s var(--ease-hydraulic);
+  }
+
+  .reveal-scale.active {
+    opacity: 1;
+    transform: scale(1);
+  }
+
   /* Stagger children */
   .stagger-children > * {
     opacity: 0;
     transform: translateY(20px);
   }
-  
+
   .stagger-children.active > *:nth-child(1) { animation: fade-in-up 0.5s 0.1s forwards; }
   .stagger-children.active > *:nth-child(2) { animation: fade-in-up 0.5s 0.2s forwards; }
   .stagger-children.active > *:nth-child(3) { animation: fade-in-up 0.5s 0.3s forwards; }
   .stagger-children.active > *:nth-child(4) { animation: fade-in-up 0.5s 0.4s forwards; }
   .stagger-children.active > *:nth-child(5) { animation: fade-in-up 0.5s 0.5s forwards; }
   .stagger-children.active > *:nth-child(6) { animation: fade-in-up 0.5s 0.6s forwards; }
+
+  /* ─── Stat counters ─────────────────────────────────────────── */
+  .stat-item {
+    position: relative;
+  }
+
+  .stat-item::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 20%;
+    height: 60%;
+    width: 1px;
+    background: linear-gradient(to bottom, transparent, rgba(128, 211, 238, 0.3), transparent);
+  }
+
+  .stat-item:last-child::after {
+    display: none;
+  }
+
+  /* ─── Scroll indicator ───────────────────────────────────────── */
+  .scroll-indicator {
+    position: absolute;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    pointer-events: none;
+    animation: bounce-gentle 2s ease-in-out infinite;
+  }
+
+  @keyframes bounce-gentle {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50%       { transform: translateX(-50%) translateY(-8px); }
+  }
+
+  /* Section accent line */
+  .section-accent {
+    display: inline-block;
+    position: relative;
+  }
+
+  .section-accent::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -6px;
+    width: 40px;
+    height: 3px;
+    background: linear-gradient(90deg, #80D3EE, transparent);
+    border-radius: 2px;
+  }
+
+  /* Decorative glow ring */
+  .icon-glow {
+    position: relative;
+  }
+
+  .icon-glow::before {
+    content: '';
+    position: absolute;
+    inset: -6px;
+    border-radius: 50%;
+    background: rgba(128, 211, 238, 0.12);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  .icon-glow:hover::before {
+    opacity: 1;
+  }
+
+  /* Animated number pop */
+  .animate-count-pop {
+    animation: count-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
+  @keyframes count-pop {
+    0%   { opacity: 0; transform: translateY(16px) scale(0.8); }
+    60%  { transform: translateY(-3px) scale(1.04); }
+    100% { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  /* Shimmer loading effect */
+  .shimmer {
+    background: linear-gradient(
+      90deg,
+      rgba(128, 211, 238, 0) 0%,
+      rgba(128, 211, 238, 0.15) 50%,
+      rgba(128, 211, 238, 0) 100%
+    );
+    background-size: 200% auto;
+    animation: shimmer 2.5s linear infinite;
+  }
+
+  @keyframes shimmer {
+    0%   { background-position: -200% center; }
+    100% { background-position:  200% center; }
+  }
+
+  /* Wave divider */
+  .wave-divider {
+    line-height: 0;
+    overflow: hidden;
+  }
+
+  .wave-divider svg {
+    display: block;
+    width: 100%;
+  }
+
+  /* Gradient border card */
+  .gradient-border {
+    position: relative;
+    background: white;
+    border-radius: 1.25rem;
+  }
+
+  .gradient-border::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(135deg, rgba(128, 211, 238, 0.4), transparent 50%, rgba(128, 211, 238, 0.2));
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  .gradient-border:hover::before {
+    opacity: 1;
+  }
 }
 
 @layer utilities {
@@ -211,15 +485,26 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
-  
+
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
-  
+
   /* Pause animation on hover */
   .pause-on-hover:hover {
     animation-play-state: paused;
   }
+
+  .animation-delay-100 { animation-delay: 0.1s; }
+  .animation-delay-200 { animation-delay: 0.2s; }
+  .animation-delay-300 { animation-delay: 0.3s; }
+  .animation-delay-400 { animation-delay: 0.4s; }
+  .animation-delay-500 { animation-delay: 0.5s; }
+  .animation-delay-600 { animation-delay: 0.6s; }
+  .animation-delay-700 { animation-delay: 0.7s; }
+  .animation-delay-800 { animation-delay: 0.8s; }
+  .animation-delay-1000 { animation-delay: 1.0s; }
+  .animation-delay-1200 { animation-delay: 1.2s; }
 }
 
 /* Reduced motion support */
@@ -229,9 +514,16 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
-  
-  .reveal {
+
+  .reveal,
+  .reveal-left,
+  .reveal-right,
+  .reveal-scale {
     opacity: 1;
     transform: none;
+  }
+
+  .hero-dots {
+    animation: none;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,6 +69,10 @@ module.exports = {
         xs: "0 1px 2px 0 rgb(0 0 0 / 0.05)",
         'glass': '0 8px 32px rgba(24, 38, 81, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
         'glow': '0 0 20px rgba(128, 211, 238, 0.4)',
+        'glow-lg': '0 0 40px rgba(128, 211, 238, 0.5), 0 0 80px rgba(128, 211, 238, 0.15)',
+        'navy-glow': '0 0 30px rgba(24, 38, 81, 0.4)',
+        'card': '0 4px 24px rgba(24, 38, 81, 0.08)',
+        'card-hover': '0 16px 48px rgba(24, 38, 81, 0.18)',
       },
       keyframes: {
         "accordion-down": {
@@ -103,24 +107,73 @@ module.exports = {
           "0%": { opacity: "0", transform: "translateX(-30px)" },
           "100%": { opacity: "1", transform: "translateX(0)" },
         },
+        "slide-in-right": {
+          "0%": { opacity: "0", transform: "translateX(30px)" },
+          "100%": { opacity: "1", transform: "translateX(0)" },
+        },
         "scale-in": {
           "0%": { opacity: "0", transform: "scale(0.8)" },
           "100%": { opacity: "1", transform: "scale(1)" },
+        },
+        "scale-in-bounce": {
+          "0%": { opacity: "0", transform: "scale(0.7)" },
+          "70%": { transform: "scale(1.05)" },
+          "100%": { opacity: "1", transform: "scale(1)" },
+        },
+        "glow-breathe": {
+          "0%, 100%": { boxShadow: "0 0 8px rgba(128, 211, 238, 0.3), 0 0 0 rgba(128, 211, 238, 0)" },
+          "50%": { boxShadow: "0 0 30px rgba(128, 211, 238, 0.7), 0 0 60px rgba(128, 211, 238, 0.2)" },
+        },
+        "spin-slow": {
+          from: { transform: "rotate(0deg)" },
+          to: { transform: "rotate(360deg)" },
+        },
+        "bounce-gentle": {
+          "0%, 100%": { transform: "translateX(-50%) translateY(0)" },
+          "50%": { transform: "translateX(-50%) translateY(-8px)" },
+        },
+        "gradient-shift": {
+          "0%, 100%": { backgroundPosition: "0% 50%" },
+          "50%": { backgroundPosition: "100% 50%" },
+        },
+        "shimmer": {
+          "0%": { backgroundPosition: "-200% center" },
+          "100%": { backgroundPosition: "200% center" },
+        },
+        "count-pop": {
+          "0%": { opacity: "0", transform: "translateY(16px) scale(0.8)" },
+          "60%": { transform: "translateY(-4px) scale(1.05)" },
+          "100%": { opacity: "1", transform: "translateY(0) scale(1)" },
+        },
+        "border-glow": {
+          "0%, 100%": { borderColor: "rgba(128, 211, 238, 0.2)" },
+          "50%": { borderColor: "rgba(128, 211, 238, 0.7)" },
+        },
+        "slide-down": {
+          "0%": { opacity: "0", transform: "translateY(-10px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
         },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "caret-blink": "caret-blink 1.25s ease-out infinite",
-        // Sponsor marquee animation - change the duration (15s) to adjust speed
-        // Lower value = faster, higher value = slower. Original was 40s.
-        // Current setting: 15s = 2.67x speed (40s / 15s ≈ 2.67x)
         "marquee": "marquee 10s linear infinite",
         "pulse-glow": "pulse-glow 2s ease-in-out infinite",
         "float": "float 4s ease-in-out infinite",
         "fade-in-up": "fade-in-up 0.7s ease-out both",
-        "slide-in-left": "slide-in-left 0.5s ease-out both",
+        "slide-in-left": "slide-in-left 0.7s ease-out both",
+        "slide-in-right": "slide-in-right 0.7s ease-out both",
         "scale-in": "scale-in 0.4s ease-out both",
+        "scale-in-bounce": "scale-in-bounce 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) both",
+        "glow-breathe": "glow-breathe 3s ease-in-out infinite",
+        "spin-slow": "spin-slow 8s linear infinite",
+        "bounce-gentle": "bounce-gentle 2s ease-in-out infinite",
+        "gradient-shift": "gradient-shift 4s ease infinite",
+        "shimmer": "shimmer 2.5s linear infinite",
+        "count-pop": "count-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) both",
+        "border-glow": "border-glow 2.5s ease-in-out infinite",
+        "slide-down": "slide-down 0.4s ease-out both",
       },
     },
   },


### PR DESCRIPTION
## Summary

A comprehensive animation, polish, and bug-fix pass across the entire site.

---

## ✨ New Animations & Effects

### Hero sections (all pages)
- **Staggered text entrance** — each hero element (badge, h1, h2, tagline, CTA) fades and slides up with increasing delays, creating a smooth cinematic entrance instead of everything popping in at once
- **Animated dot-grid overlay** — subtle circuit-board pattern that slowly drifts, adding depth without distraction
- **Ambient glow orb** — soft radial gradient behind hero content gives an atmospheric, modern feel
- **Scroll-down indicator** — animated chevron + line at the bottom of the home hero cues users to scroll

### Home page — new Stats Bar
A new section between the hero and "Our Mission" shows the team's key figures with a **count-pop bounce animation** triggered when the section scrolls into view:
- 22+ Years of Excellence
- 120 LBS Competition Robot
- 5 Schools Represented
- 6 WK Build Season

### Scroll-reveal variants
Added `reveal-left`, `reveal-right`, and `reveal-scale` variants alongside the existing `reveal`. Two-column sections now alternate slide-from-left (text) / slide-from-right (media) for a more dynamic feel.

### Card hover upgrades
- **Benefit cards & Role cards** (Join page): bottom accent bar slides in on hover using `transform: scaleX()`
- **Impact cards** (Donate page): top shimmer accent line + deeper lift
- All cards use smoother `cubic-bezier(0.16, 1, 0.3, 1)` easing instead of plain `ease`

### Button effects
- `btn-primary` and `btn-primary-light` now have a **sliding fill** on hover (`scaleX` from left) instead of just a background change
- Arrow icons inside buttons translate right on hover

### Navigation
- Active page gets a **pill highlight** and an indicator dot below the label
- Logo scales slightly on hover
- Hover items get a subtle pill background

### Sponsor carousel
- Arrow buttons get a glow border and scale on hover
- Sponsor logo hover now adds a `drop-shadow` glow in the brand's light-blue colour

### New Tailwind animations added
`glow-breathe`, `bounce-gentle`, `count-pop`, `shimmer`, `gradient-shift`, `slide-in-right`, `scale-in-bounce`, `spin-slow`, `border-glow`, `slide-down` — plus corresponding utility classes and `animation-delay-*` helpers up to 1200 ms.

---

## 🐛 Bug Fixes

| File | Issue | Fix |
|------|-------|-----|
| `Join.tsx` | Typo `atleast` | → `at least` |
| `Join.tsx` | Typo `provivded` | → `provided` |
| `Join.tsx` | Day abbreviation `Wen` | → `Wed` |
| `Join.tsx` | Informal `250 dollar club fee` | → `$250 club fee` |
| `App.tsx` | Sponsors 8 & 9 had empty `name` ("Sponsor 8") and empty `description`, causing an awkward blank dialog | → Replaced with a meaningful fallback name and description |
| `App.tsx` | ~90 lines of dead commented-out `ScrollExpandMedia`/`DirectionalText` code | Removed entirely |
| All pages | `IntersectionObserver` only watched `.reveal`, missing the new variant classes | Extended selector to include `reveal-left`, `reveal-right`, `reveal-scale` |

---

## 🎨 Style / QoL

- Rewrote `App.css`, `Join.css`, `Donate.css` with better easing, card polish, and scrollbar styling
- Added `shadow-card` / `shadow-card-hover` / `glow-lg` / `navy-glow` shadow tokens
- Added `section-accent` underline decoration on section sub-labels
- All new animations respect `prefers-reduced-motion`
- Build passes cleanly (`tsc -b && vite build`) ✅

https://claude.ai/code/session_01Vw1QmzRiUzZdrssxyzLBWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw1QmzRiUzZdrssxyzLBWn)_